### PR TITLE
Duotao/empty search handle

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -459,7 +459,6 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
   //when typing, perform a throttled search
   var streamSearch = debounce(function(){
     if ($scope.searchInput){
-      console.log('stream');
       $state.go('main.search',{query:$scope.searchInput},{location:'replace'});
     }
   },streamSearchDelay);
@@ -475,7 +474,6 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
     if ($scope.searchInput){
       streamSearch();
       if(!initSearch) {
-        console.log('search');
         initSearch = true;
         $state.go('main.search',{query:$scope.searchInput},{location:'replace'});
       }

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -9,7 +9,6 @@ hitsTheBooks.run(function($rootScope, $state){
 //a more flexible keypress directive that maps keycodes to functions
 hitsTheBooks.directive('ngHtbKeypress', function() {
     return function(scope, element, attrs) {
-
         element.bind("keydown keypress", function(event) {
             var keyCode = event.which || event.keyCode;
             var map = scope.$eval("("+attrs.ngHtbKeypress+")");
@@ -93,7 +92,6 @@ hitsTheBooks.filter('ordinal', function() {
 
 hitsTheBooks.config(function($stateProvider, $locationProvider) {
   $stateProvider
-
     .state('account', { url: '/account',
       views:{'account' : {
           templateUrl: '/partials/account',
@@ -131,7 +129,11 @@ hitsTheBooks.config(function($stateProvider, $locationProvider) {
       resolve : {
         //get results of search from server
         results: function(Api, $stateParams) {
-          return Api.search($stateParams.query);
+          if ($stateParams.query) {
+            return Api.search($stateParams.query);
+          } else {
+            window.location.replace('/');
+          }
         }
       },
       url : 'search?query',
@@ -392,7 +394,7 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
   }
 
   $scope.handleSearchPaneClick = function(){
-    if ($state.includes('main.detail')) {
+    if ($state.includes('main.detail') && $scope.searchInput) {
       $state.go('main.search',{query: $scope.searchInput});
     }
   }
@@ -401,7 +403,7 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
   $scope.$on('$stateChangeStart',
   function(event, toState, toParams, fromState, fromParams){
     //if we're heading home, erase the search box
-    if (toState.name=="main"){
+    if (toState.name == "main"){
       //while this ↴ looks superfluous, it's necessary to change
       //the input value in time for updateSearchBox to resize.
       $('input#search-box').val('');
@@ -415,7 +417,7 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
   function(event, toState, toParams, fromState, fromParams){
     var $sr = $('#search-results');
 
-    if (fromState.name=="main.search" && toState.name !== "main.search") {
+    if (fromState.name == "main.search" && toState.name !== "main.search") {
       $sr.transist({'add':['minimized']},['height'],200);
     }
 
@@ -424,11 +426,12 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
       $sr.transist({'remove':['minimized']},['height'],200);
     }
   });
+
   //transists continued...
   $rootScope.$on('$stateChangeSuccess',
   function(event, toState, toParams, fromState, fromParams){
     var $sr = $('#search-results');
-    if (fromState.name=="main" && toState.name=="main.search") {
+    if (fromState.name == "main" && toState.name == "main.search") {
       $sr.transist({'remove':['minimized']},['height'],200);
     }
   });
@@ -456,6 +459,7 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
   //when typing, perform a throttled search
   var streamSearch = debounce(function(){
     if ($scope.searchInput){
+      console.log('stream');
       $state.go('main.search',{query:$scope.searchInput},{location:'replace'});
     }
   },streamSearchDelay);
@@ -471,6 +475,7 @@ hitsTheBooks.controller('mainController', function($scope, $rootScope, $state, $
     if ($scope.searchInput){
       streamSearch();
       if(!initSearch) {
+        console.log('search');
         initSearch = true;
         $state.go('main.search',{query:$scope.searchInput},{location:'replace'});
       }

--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -128,12 +128,17 @@ hitsTheBooks.config(function($stateProvider, $locationProvider) {
     .state('main.search',{
       resolve : {
         //get results of search from server
-        results: function(Api, $stateParams) {
+        results: function(Api, $stateParams, $q) {
           if ($stateParams.query) {
             return Api.search($stateParams.query);
           } else {
-            window.location.replace('/');
+            return $q.resolve(null);
           }
+        }
+      },
+      onEnter: function($stateParams, $state) {
+        if ($stateParams.query == null) {
+          $state.go('main');
         }
       },
       url : 'search?query',
@@ -216,9 +221,7 @@ hitsTheBooks.controller('headerController', function($scope, $rootScope, $state,
     function(event, toState, toParams, fromState, fromParams) {
     //header transitions
     if (toState.name=="main"){
-      if(fromState.name){
         $('header').transist({'remove':['minimized']},['height'],200)
-      }
     } else if(fromState.name=="main" && toState.name.indexOf('account') == -1){
       $('header').transist({'add':['minimized']},['height'],200)
     } else if(!fromState.name){ //init


### PR DESCRIPTION
### Changes
This bug comes from two sources: '/search' initialization and the search pane click event. Here are my fixes for each of them:
1. If users directly go to search without parameters, they will be redirected to the main page.
2. For the onclick search, I added a protection to prevent empty search box from activating the state transists.
Can either of you verify this?